### PR TITLE
Bump Jenkins version from 2.479.1 -> 2.479.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <!-- Dependency versions -->
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <version.unleash-maven-plugin>3.2.1</version.unleash-maven-plugin>
     <version.unleash-scm-provider-git>3.3.0</version.unleash-scm-provider-git>
 


### PR DESCRIPTION
Bump Jenkins version from 2.479.1 -> 2.479.3 to comply with recent Dependabot PR merges.