### PR TITLE
Remove obsolete .github/release-drafter.yml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,1 +1,0 @@
-_extends: .github


### PR DESCRIPTION
Following instructions at [Configure Release Drafter](https://www.jenkins.io/doc/developer/publishing/releasing-cd/#configure-release-drafter) `.github/release-drafter.yml` is being removed.

Refer to e.g. [pipeline-maven-plugin PR 1422](https://github.com/jenkinsci/pipeline-maven-plugin/pull/1422)